### PR TITLE
Move over to new Azure SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ mvn compile exec:java
 > * Delete the container.
 
 ### SDK Versions
+You will find the following folders: storage-blobs-java-v10-quickstart-v3, which references the version 11.0.0 of the SDK and storage-blobs-java-v10-quickstart-v4, which uses the version 12.0.0 of the SDK.
+
 * To use the latest Azure SDK version [storage-blobs-java-v10-quickstart-v4](./storage-blobs-java-v10-quickstart-v4) please add the following dependency to the Maven pom.xml file:
 ```xml
    <dependency>

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ mvn compile exec:java
 
 ### SDK Versions
 You will find the following folders: storage-blobs-dotnet-quickstart-v3, which references the version 11.0.0 of the SDK and storage-blobs-dotnet-quickstart-v4, which uses the version 12.0.0 of the SDK.
-* To use the latest Azure SDK version [storage-blobs-java-v10-quickstart-v4] please add the following dependency to the Maven pom.xml file:
+* To use the latest Azure SDK version [storage-blobs-java-v10-quickstart-v4](./storage-blobs-java-v10-quickstart-v4) please add the following dependency to the Maven pom.xml file:
 ```xml
    <dependency>
      <groupId>com.azure</groupId>
@@ -70,7 +70,7 @@ You will find the following folders: storage-blobs-dotnet-quickstart-v3, which r
      <version>12.0.0</version>
    </dependency>
 ```
-* For the previous Azure SDK version [storage-blobs-java-v10-quickstart-v3] please add the following dependencies to the Maven pom.xml file:
+* For the previous Azure SDK version [storage-blobs-java-v10-quickstart-v3](./storage-blobs-java-v10-quickstart-v3) please add the following dependency to the Maven pom please add the following dependencies to the Maven pom.xml file:
 ```xml
    <dependency>
      <groupId>com.microsoft.azure</groupId>

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ mvn compile exec:java
 > * Delete the container.
 
 ### SDK Versions
-You will find the following folders: storage-blobs-dotnet-quickstart-v3, which references the version 11.0.0 of the SDK and storage-blobs-dotnet-quickstart-v4, which uses the version 12.0.0 of the SDK.
 * To use the latest Azure SDK version [storage-blobs-java-v10-quickstart-v4](./storage-blobs-java-v10-quickstart-v4) please add the following dependency to the Maven pom.xml file:
 ```xml
    <dependency>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,31 @@
 # Quickstart with Azure Storage Blobs SDK V10 for Java
 
+### SDK Versions
+You will find the following folders: storage-blobs-java-v10-quickstart-v3, which references the version 11.0.0 of the SDK and storage-blobs-java-v10-quickstart-v4, which uses the version 12.0.0 of the SDK.
+
+* To use the latest Azure SDK version [storage-blobs-java-v10-quickstart-v4](./storage-blobs-java-v10-quickstart-v4) please add the following dependency to the Maven pom.xml file:
+```xml
+   <dependency>
+     <groupId>com.azure</groupId>
+     <artifactId>azure-storage-common</artifactId>
+     <version>12.0.0</version>
+   </dependency>
+
+    <dependency>
+     <groupId>com.azure</groupId>
+     <artifactId>azure-storage-blob</artifactId>
+     <version>12.0.0</version>
+   </dependency>
+```
+* For the previous Azure SDK version [storage-blobs-java-v10-quickstart-v3](./storage-blobs-java-v10-quickstart-v3) please add the following dependency to the Maven pom please add the following dependencies to the Maven pom.xml file:
+```xml
+   <dependency>
+     <groupId>com.microsoft.azure</groupId>
+     <artifactId>azure-storage-blob</artifactId>
+     <version>11.0.0</version>
+   </dependency>
+```
+
 ### Prerequisites
 
 If you don't have an Azure subscription, create a [free account](https://azure.microsoft.com/free/?WT.mc_id=A261C142F) before you begin.
@@ -53,32 +79,6 @@ mvn compile exec:java
 > * Download a blob to file.
 > * Delete a blob.
 > * Delete the container.
-
-### SDK Versions
-You will find the following folders: storage-blobs-java-v10-quickstart-v3, which references the version 11.0.0 of the SDK and storage-blobs-java-v10-quickstart-v4, which uses the version 12.0.0 of the SDK.
-
-* To use the latest Azure SDK version [storage-blobs-java-v10-quickstart-v4](./storage-blobs-java-v10-quickstart-v4) please add the following dependency to the Maven pom.xml file:
-```xml
-   <dependency>
-     <groupId>com.azure</groupId>
-     <artifactId>azure-storage-common</artifactId>
-     <version>12.0.0</version>
-   </dependency>
-
-    <dependency>
-     <groupId>com.azure</groupId>
-     <artifactId>azure-storage-blob</artifactId>
-     <version>12.0.0</version>
-   </dependency>
-```
-* For the previous Azure SDK version [storage-blobs-java-v10-quickstart-v3](./storage-blobs-java-v10-quickstart-v3) please add the following dependency to the Maven pom please add the following dependencies to the Maven pom.xml file:
-```xml
-   <dependency>
-     <groupId>com.microsoft.azure</groupId>
-     <artifactId>azure-storage-blob</artifactId>
-     <version>11.0.0</version>
-   </dependency>
-```
 
 ### Resources
 * [Azure Storage SDK v10 for Java](https://github.com/azure/azure-storage-java)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ mvn compile exec:java
 > * Delete a blob.
 > * Delete the container.
 
-# Azure SDK versions
+### Folders Introduction 
+You will find the following folders: storage-blobs-dotnet-quickstart-v3, which references the version 11.0.0 of the SDK and storage-blobs-dotnet-quickstart-v4, which uses the version 12.0.0 of the SDK.
 * To use the latest Azure SDK version [storage-blobs-java-v10-quickstart-v4] please add the following dependency to the Maven pom.xml file:
 ```xml
    <dependency>

--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ If you don't have an Azure subscription, create a [free account](https://azure.m
 
 ### Create a Storage Account using the Azure portal
 
-Step 1 : Create a new general-purpose storage account to use for this tutorial. 
+Step 1 : Create a new general-purpose storage account to use for this tutorial.
 
-*  Go to the [Azure Portal](https://portal.azure.com) and log in using your Azure account. 
-*  Select **New** > **Storage** > **Storage account**. 
-*  Select your Subscription. 
-*  For `Resource group`, create a new one and give it a unique name. 
-*  Enter a name for your storage account. The name must be between 3 and 24 characters in length and may contain numbers and lowercase letters only. It must also be unique.
+*  Go to the [Azure Portal](https://portal.azure.com) and log in using your Azure account.
+*  Select **New** > **Storage** > **Storage account**.
+*  Select your Subscription.
+*  For `Resource group`, create a new one and give it a unique name.
+*  Enter a name for your storage account.
 *  Select the `Location` to use for your Storage Account.
 *  Set `Account kind` to **StorageV2(general purpose v2)**.
-*  Set `Performance` to **Standard**. 
+*  Set `Performance` to **Standard**.
 *  Set `Replication` to **Locally-redundant storage (LRS)**.
 *  Set `Secure transfer required` to **Disabled**.
-*  Check **Review + create** and click **Create** to create your Storage Account. 
+*  Check **Review + create** and click **Create** to create your Storage Account.
 
 Step 2 : Copy and save keys.
 
@@ -38,13 +38,13 @@ setx AZURE_STORAGE_ACCOUNT "<youracountname>"
 setx AZURE_STORAGE_ACCESS_KEY "<youraccountkey>"
 ```
 
-At this point, you can run this application using maven: `mvn compile exec:java`. It creates its own file to upload and download, and then cleans up after itself by deleting everything at the end. 
+At this point, you can run this application using maven: `mvn compile exec:java`. It creates its own file to upload and download, and then cleans up after itself by deleting everything at the end.
 
 ```
 mvn compile exec:java
 ```
 
-### This Quickstart shows how to do some basic operations of Storage Blobs. 
+### This Quickstart shows how to do the following operations of Storage Blobs. 
 
 > * Create a Storage Account using the Azure portal.
 > * Create a container.
@@ -54,7 +54,7 @@ mvn compile exec:java
 > * Delete a blob.
 > * Delete the container.
 
-### Folders Introduction 
+### SDK Versions
 You will find the following folders: storage-blobs-dotnet-quickstart-v3, which references the version 11.0.0 of the SDK and storage-blobs-dotnet-quickstart-v4, which uses the version 12.0.0 of the SDK.
 * To use the latest Azure SDK version [storage-blobs-java-v10-quickstart-v4] please add the following dependency to the Maven pom.xml file:
 ```xml
@@ -70,7 +70,7 @@ You will find the following folders: storage-blobs-dotnet-quickstart-v3, which r
      <version>12.0.0</version>
    </dependency>
 ```
-* For the previous stable Azure SDK version [storage-blobs-java-v10-quickstart-v3] please add the following dependencies to the Maven pom.xml file :
+* For the previous Azure SDK version [storage-blobs-java-v10-quickstart-v3] please add the following dependencies to the Maven pom.xml file:
 ```xml
    <dependency>
      <groupId>com.microsoft.azure</groupId>
@@ -79,12 +79,11 @@ You will find the following folders: storage-blobs-dotnet-quickstart-v3, which r
    </dependency>
 ```
 
-
-## Resources
+### Resources
 * [Azure Storage SDK v10 for Java](https://github.com/azure/azure-storage-java)
 * [API Reference](https://docs.microsoft.com/en-us/java/api/overview/azure/storage/blob?view=azure-java-preview)
 
-# Contributing
+### Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Step 1 : Create a new general-purpose storage account to use for this tutorial.
 
 Step 2 : Copy and save keys.
 
- * After your storage account is created, it is pinned to the dashboard. Click on it to open it. Under SETTINGS, click **Access keys**. Select a key and copy the **key1** to the clipboard, then paste it into text editor for later use.
+ * After your Storage Account is created. Click on it to open it. Select **Settings** > **Access keys** > **key1/key2**, Select a key and copy the **Key** to the clipboard, then paste it into text editor for later use.
 
 ### Set credentials in environment variables 
 


### PR DESCRIPTION
### Purpose
Move over this sample to new Azure SDK:

1. Move the original file to storage-blobs-java-v10-quickstart-v3 folder
2. Add folder storage-blobs-java-v10-quickstart-v4 for the sample referenced to the new SDK
3. Add two sections to the readme: 
    - SDK Versions
    - This Quickstart shows how to do the following operations of Storage Blobs
   

### What old sample do:
![image](https://user-images.githubusercontent.com/49467823/67459838-0b6b6800-f66c-11e9-8c8a-f8847576116d.png)

### What can be updated to V4:
![image](https://user-images.githubusercontent.com/49467823/68448705-4e5a3d80-021f-11ea-9f41-d2a877bc301b.png)


