### PR TITLE
Move over to new Azure SDK

### DIFF
--- a/storage-blobs-java-v10-quickstart-v11/.settings/org.eclipse.jdt.apt.core.prefs
+++ b/storage-blobs-java-v10-quickstart-v11/.settings/org.eclipse.jdt.apt.core.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.apt.aptEnabled=false

--- a/storage-blobs-java-v10-quickstart-v11/.settings/org.eclipse.jdt.core.prefs
+++ b/storage-blobs-java-v10-quickstart-v11/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
-org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
-org.eclipse.jdt.core.compiler.processAnnotations=disabled
-org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8

--- a/storage-blobs-java-v10-quickstart-v11/.settings/org.eclipse.m2e.core.prefs
+++ b/storage-blobs-java-v10-quickstart-v11/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/storage-blobs-java-v10-quickstart-v11/src/main/java/quickstart/Quickstart.java
+++ b/storage-blobs-java-v10-quickstart-v11/src/main/java/quickstart/Quickstart.java
@@ -10,12 +10,9 @@ import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.channels.AsynchronousFileChannel;
-import java.nio.channels.FileChannel;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.security.InvalidKeyException;
 
-import com.microsoft.azure.storage.blob.BlobRange;
 import com.microsoft.azure.storage.blob.BlockBlobURL;
 import com.microsoft.azure.storage.blob.ContainerURL;
 import com.microsoft.azure.storage.blob.ListBlobsOptions;
@@ -28,10 +25,8 @@ import com.microsoft.azure.storage.blob.models.BlobItem;
 import com.microsoft.azure.storage.blob.models.ContainerCreateResponse;
 import com.microsoft.azure.storage.blob.models.ContainerListBlobFlatSegmentResponse;
 import com.microsoft.rest.v2.RestException;
-import com.microsoft.rest.v2.util.FlowableUtil;
 
 import io.reactivex.*;
-import io.reactivex.Flowable;
 
 public class Quickstart {
     static File createTempFile() throws IOException {


### PR DESCRIPTION
### Purpose
Move over this sample to new Azure SDK:

1. Move the original file to storage-blobs-java-v10-quickstart-v11 folder
2. Add folder storage-blobs-java-v10-quickstart-v12 for the sample referenced to the new SDK
3. Add two sections to the readme: 
    - SDK Versions
    - This Quickstart shows how to do the following operations of Storage Blobs
   

### What old sample do:
![image](https://user-images.githubusercontent.com/49467823/67459838-0b6b6800-f66c-11e9-8c8a-f8847576116d.png)

### What can be updated to V12:
![image](https://user-images.githubusercontent.com/49467823/68448705-4e5a3d80-021f-11ea-9f41-d2a877bc301b.png)


